### PR TITLE
Add Firebase iOS SDK via Swift Package Manager

### DIFF
--- a/Restless.xcodeproj/project.pbxproj
+++ b/Restless.xcodeproj/project.pbxproj
@@ -6,6 +6,14 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		2518391B2EA2E1A1009D7808 /* FirebaseAI in Frameworks */ = {isa = PBXBuildFile; productRef = 2518391A2EA2E1A1009D7808 /* FirebaseAI */; };
+		2518391D2EA2E1A1009D7808 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2518391C2EA2E1A1009D7808 /* FirebaseAnalytics */; };
+		2518391F2EA2E1A1009D7808 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2518391E2EA2E1A1009D7808 /* FirebaseAnalyticsCore */; };
+		251839212EA2E1A1009D7808 /* FirebaseAnalyticsIdentitySupport in Frameworks */ = {isa = PBXBuildFile; productRef = 251839202EA2E1A1009D7808 /* FirebaseAnalyticsIdentitySupport */; };
+		251839232EA2E1A1009D7808 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 251839222EA2E1A1009D7808 /* FirebaseAppCheck */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		256D3C772E833C03009FDC78 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -52,6 +60,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				251839212EA2E1A1009D7808 /* FirebaseAnalyticsIdentitySupport in Frameworks */,
+				2518391D2EA2E1A1009D7808 /* FirebaseAnalytics in Frameworks */,
+				2518391F2EA2E1A1009D7808 /* FirebaseAnalyticsCore in Frameworks */,
+				251839232EA2E1A1009D7808 /* FirebaseAppCheck in Frameworks */,
+				2518391B2EA2E1A1009D7808 /* FirebaseAI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,6 +125,11 @@
 			);
 			name = Restless;
 			packageProductDependencies = (
+				2518391A2EA2E1A1009D7808 /* FirebaseAI */,
+				2518391C2EA2E1A1009D7808 /* FirebaseAnalytics */,
+				2518391E2EA2E1A1009D7808 /* FirebaseAnalyticsCore */,
+				251839202EA2E1A1009D7808 /* FirebaseAnalyticsIdentitySupport */,
+				251839222EA2E1A1009D7808 /* FirebaseAppCheck */,
 			);
 			productName = Restless;
 			productReference = 256D3C692E833C01009FDC78 /* Restless.app */;
@@ -195,6 +213,9 @@
 			);
 			mainGroup = 256D3C602E833C01009FDC78;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				251839192EA2E1A1009D7808 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 256D3C6A2E833C01009FDC78 /* Products */;
 			projectDirPath = "";
@@ -552,6 +573,45 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		251839192EA2E1A1009D7808 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2518391A2EA2E1A1009D7808 /* FirebaseAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 251839192EA2E1A1009D7808 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAI;
+		};
+		2518391C2EA2E1A1009D7808 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 251839192EA2E1A1009D7808 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		2518391E2EA2E1A1009D7808 /* FirebaseAnalyticsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 251839192EA2E1A1009D7808 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsCore;
+		};
+		251839202EA2E1A1009D7808 /* FirebaseAnalyticsIdentitySupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 251839192EA2E1A1009D7808 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsIdentitySupport;
+		};
+		251839222EA2E1A1009D7808 /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 251839192EA2E1A1009D7808 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 256D3C612E833C01009FDC78 /* Project object */;
 }

--- a/Restless.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Restless.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,132 @@
+{
+  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "541ac342abead313f2ce0ccf33278962b5c1e43c",
+        "version" : "12.4.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "2ba031f43ef88a7f6631c84d23794eb99751e891",
+        "version" : "3.1.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "52713644ce2831bb687ded4aefd5e5c9f15565c5",
+        "version" : "12.4.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "fb7f2740b1570d2f7599c6bb9531bf4fad6974b7",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "c6fe6442e6a64250495669325044052e113e990c",
+        "version" : "1.32.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
Integrated Firebase iOS SDK and related products (FirebaseAI, FirebaseAnalytics, FirebaseAnalyticsCore, FirebaseAnalyticsIdentitySupport, FirebaseAppCheck) into the Xcode project using Swift Package Manager. Updated project configuration to include new package dependencies.